### PR TITLE
Add explicit per-process ctx initialization and remove global state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,8 @@ jobs:
           name: codecov-umbrella
           flags: unittests
           env_vars: OS,PYTHON
-          file: ./coverage.xml
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Success Reporting
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ __pycache__
 /htmlcov
 /coverage.*
 /.coverage
+/.coverage.*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ releases, in reverse chronological order.
 0.8.0 (2024-XX-XX)
 ------------------
 
+Improvements
+^^^^^^^^^^^^
+
+* ReformatOptimized the ``gstore.repo.sync`` function to dynamically
+  adjust the number of worker processes based on the number of
+  repositories, ensuring no unnecessary processes are created when
+  tasks are fewer than available CPUs.
+
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,14 @@ releases, in reverse chronological order.
 0.8.0 (2024-XX-XX)
 ------------------
 
-* Work In Progress
+Bug Fixes
+^^^^^^^^^
+
+* Fixed handling of host assignment when a token is provided but no
+  host is explicitly specified. Previously, the token was incorrectly
+  used as both the token and the host in such cases.
+
+----
 
 
 0.7.0 (2024-11-30)

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -7,11 +7,11 @@ This document outlines essential guidelines for maintaining the ``gstore`` proje
 Overview
 ========
 
-The ``gstore`` project is a CLI tool for synchronizing GitHub repositories. It is managed via poetry and adheres to modern Python packaging standards. This guide assumes familiarity with GitHub Actions, ``poetry``, and common Python development workflows.
+This is managed via poetry and adheres to modern Python packaging standards. This guide assumes familiarity with GitHub Actions, ``poetry``, and common Python development workflows.
 
 Key configurations:
 
-- **Python Versions Supported:** 3.9, 3.10, 3.11, 3.12
+- **Python Versions Supported:** >= 3.9
 - **Build Tool:** ``poetry``
 - **Primary Dependencies:** ``pygithub``, ``gitpython``
 - **Documentation Tool:** ``sphinx``

--- a/debug.el
+++ b/debug.el
@@ -1,0 +1,26 @@
+;; Copyright (C) 2020-2024 Serghei Iakovlev <gnu@serghei.pl>
+;;
+;; This file is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;; Eval Buffer with `M-x eval-buffer' to register the newly created template.
+
+(dap-register-debug-template
+ "gstore :: Debug Console App"
+  (list :type "python"
+        :request "launch"
+        :name "gstore :: Debug Console App"
+        :program "${workspaceFolder}/gstore/__main__.py"
+        :cwd "${workspaceFolder}"
+        :args '("-o" "myorg" "${workspaceFolder}/output")
+        :env '(("GITHUB_TOKEN" . "secret"))))

--- a/gstore/__init__.py
+++ b/gstore/__init__.py
@@ -18,28 +18,6 @@
 This module tracks the version of the package as well as the base
 package info used by various functions within gstore.
 
-Modules:
-
-    __main__
-    args
-    cli
-    client
-    env
-    exceptions
-    logger
-    models
-    repo
-
-Misc variables:
-
-    __copyright__
-    __version__
-    __license__
-    __author__
-    __author_email__
-    __url__
-    __description__
-
 Refer to the `documentation <https://gstore.readthedocs.io/>`_ for
 details on the use of this package.
 

--- a/gstore/__main__.py
+++ b/gstore/__main__.py
@@ -17,10 +17,6 @@
 
 Invoke as ``gstore`` or ``python -m gstore``.
 
-Functions:
-
-    init() -> None
-
 """
 
 import sys

--- a/gstore/args.py
+++ b/gstore/args.py
@@ -15,10 +15,11 @@
 
 """Command line argument parsing methods for gstore."""
 
+from argparse import ArgumentParser, HelpFormatter, Namespace, SUPPRESS
 import os
 import sys
 import textwrap as _textwrap
-from argparse import ArgumentParser, HelpFormatter, Namespace, SUPPRESS
+from typing import Optional
 
 from gstore import __copyright__, __version__
 from gstore import env
@@ -129,7 +130,7 @@ def parser_add_options(parser: ArgumentParser) -> ArgumentParser:
     return parser
 
 
-def argparse() -> Namespace or None:
+def argparse() -> Optional[Namespace]:
     """
     The function initializes command line arguments parser.
 

--- a/gstore/args.py
+++ b/gstore/args.py
@@ -15,10 +15,10 @@
 
 """Command line argument parsing methods for gstore."""
 
-from argparse import ArgumentParser, HelpFormatter, Namespace, SUPPRESS
 import os
 import sys
 import textwrap as _textwrap
+from argparse import ArgumentParser, HelpFormatter, Namespace, SUPPRESS
 from typing import Optional
 
 from gstore import __copyright__, __version__

--- a/gstore/args.py
+++ b/gstore/args.py
@@ -95,7 +95,7 @@ def parser_add_options(parser: ArgumentParser) -> ArgumentParser:
     ogroup.add_argument('--token', dest='token', default=token, type=str,
                         help='An authentication token for GitHub API requests')
 
-    ogroup.add_argument('--host', dest='host', default=env.lookup_token(),
+    ogroup.add_argument('--host', dest='host', default=env.get_host(),
                         type=str, help='The GitHub API hostname')
 
     ogroup.add_argument('-o', '--org', dest='org', action='append', type=str,

--- a/gstore/env.py
+++ b/gstore/env.py
@@ -21,6 +21,8 @@ used by various functions within gstore.
 """
 
 import os
+from typing import Optional
+
 
 TOKEN_NAMES = (
     'GH_TOKEN',
@@ -30,7 +32,7 @@ TOKEN_NAMES = (
 )
 
 
-def lookup_token() -> str or None:
+def lookup_token() -> Optional[str]:
     """Lookup a personal access token from environment variables.
 
     This function looks for token variable in the following order:
@@ -51,7 +53,7 @@ def lookup_token() -> str or None:
     return None
 
 
-def get_host() -> str or None:
+def get_host() -> Optional[str]:
     """Get GitHub API hostname from GH_HOST environment variable.
 
     This function may return None if there is no environment
@@ -63,7 +65,7 @@ def get_host() -> str or None:
     return os.environ.get('GH_HOST') or None
 
 
-def get_target() -> str or None:
+def get_target() -> Optional[str]:
     """Get base target to sync repos.
 
     This function may return None if there is no environment

--- a/gstore/env.py
+++ b/gstore/env.py
@@ -18,16 +18,6 @@
 Provides a convenient way to work with environment variables
 used by various functions within gstore.
 
-Functions:
-
-    lookup_token() -> str or None
-    get_host() -> str or None
-    get_target() -> str or None
-
-Data:
-
-    TOKEN_NAMES
-
 """
 
 import os

--- a/gstore/exceptions.py
+++ b/gstore/exceptions.py
@@ -13,17 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Helper routines and classes to work exceptions.
-
-Classes:
-
-    Error
-
-Functions:
-
-    parse_git_errors() -> list
-
-"""
+"""Helper routines and classes to work exceptions."""
 
 import re
 

--- a/gstore/repo.py
+++ b/gstore/repo.py
@@ -160,9 +160,9 @@ def sync(org: Organization, repos: list, base_path: str, **kwargs):
     :keyword bool quiet: Disable info logging
     :keyword int jobs: the number of worker processes to use
     """
-    verbose = kwargs.get('verbose', False)
-    quiet = kwargs.get('quiet', False)
-    jobs = kwargs.get('jobs', multiprocessing.cpu_count())
+    verbose = kwargs.get('verbose') or False
+    quiet = kwargs.get('quiet') or False
+    jobs = kwargs.get('jobs') or multiprocessing.cpu_count()
 
     setup_logger(verbose, quiet)
     main_logger = logging.getLogger(__name__)

--- a/gstore/repo.py
+++ b/gstore/repo.py
@@ -15,11 +15,11 @@
 
 """Repository classes used to wrap git classes for gstore."""
 
-from dataclasses import dataclass
 import logging
 import multiprocessing
 import os
 import shutil
+from dataclasses import dataclass
 from typing import Optional
 
 import git
@@ -123,7 +123,7 @@ def _do_sync(repos_list):
             # local Git repository.
             if not os.path.exists(git_path):
                 ctx.logger.debug('Remove wrong formed local repo from %s',
-                                  repo_path)
+                                 repo_path)
                 shutil.rmtree(repo_path, ignore_errors=True)
 
         if os.path.exists(git_path):
@@ -145,6 +145,7 @@ def _init_process(verbose=False, quiet=False, base_path=None):
     logger = logging.getLogger(__name__)
     logger.info('Initializing process')
 
+    # pylint: disable=global-statement
     global _proc_ctx
     _proc_ctx = Context(base_path=base_path, logger=logger)
 

--- a/gstore/repo.py
+++ b/gstore/repo.py
@@ -170,7 +170,7 @@ def sync(org: Organization, repos: List[Repository], base_path: str, **kwargs):
     # Calculate the number of processes to use
     jobs = min(len(repos), requested_jobs)
     if jobs == 0:
-        logger.warning("No repositories to sync.")
+        logger.warning("No repositories to sync")
         return
 
     org_path = os.path.join(base_path, org.login)

--- a/gstore/repo.py
+++ b/gstore/repo.py
@@ -15,11 +15,12 @@
 
 """Repository classes used to wrap git classes for gstore."""
 
+from dataclasses import dataclass
 import logging
 import multiprocessing
 import os
 import shutil
-from dataclasses import dataclass
+from typing import Optional
 
 import git
 
@@ -29,89 +30,90 @@ from .models import Organization, Repository
 
 
 @dataclass
-class _Context:
+class Context:
     """Class for passing a context to parallel processes."""
 
-    base_path: str = ''
-    logger: logging.Logger = None
+    base_path: str
+    logger: logging.Logger
 
 
 # pylint: disable=invalid-name
-_ctx = _Context(logger=logging.getLogger(__name__))
+_proc_ctx: Optional[Context] = None
 
 
-def clone(repo: Repository, target: str):
+def clone(repo: Repository, ctx: Context):
     """Clone a repository to the target directory."""
-    _ctx.logger.info(
+    ctx.logger.info(
         'Clone repository to %s/%s',
         repo.org.login,
         repo.name)
+    repo_path = os.path.join(ctx.base_path, repo.org.login, repo.name)
 
-    if os.path.exists(target):
-        os.removedirs(target)
+    if os.path.exists(repo_path):
+        shutil.rmtree(repo_path, ignore_errors=True)
 
     git_url = f'git@github.com:{repo.org.login}/{repo.name}.git'
 
     try:
-        git.Repo.clone_from(
-            git_url,
-            target,
-        )
+        git.Repo.clone_from(git_url, repo_path)
     except git.GitCommandError as exception:
-        _ctx.logger.error('Failed to clone %s/%s', repo.org.login, repo.name)
+        ctx.logger.error('Failed to clone %s/%s', repo.org.login, repo.name)
         for msg in parse_git_errors(exception):
-            _ctx.logger.error(msg)
+            ctx.logger.error(msg)
 
 
-def fetch(repo: Repository, target: str):
+def fetch(repo: Repository, ctx: Context):
     """Sync a repository in the target directory."""
-    _ctx.logger.info('Update %s/%s repository', repo.org.login, repo.name)
-    local_repo = git.Repo(target)
+    ctx.logger.info('Update %s/%s repository', repo.org.login, repo.name)
+    repo_path = os.path.join(ctx.base_path, repo.org.login, repo.name)
+    local_repo = git.Repo(repo_path)
 
     if not local_repo.heads:
-        _ctx.logger.info(
-            'There are no remote branches for %s/%s, skip updating',
+        ctx.logger.info(
+            'No remote branches for %s/%s, skip fetching',
             repo.org.login,
             repo.name)
         return
 
     try:
-        _ctx.logger.debug(
-            'Download objects and refs from %s/%s repository',
+        ctx.logger.debug(
+            'Download objects and refs from %s/%s',
             repo.org.login,
             repo.name)
         local_repo.git.fetch(['--prune', '--quiet'])
 
-        _ctx.logger.debug(
-            'Fetch from and integrate with %s/%s repository',
+        ctx.logger.debug(
+            'Pulling all branches from %s/%s',
             repo.org.login,
             repo.name)
         local_repo.git.pull(['--all', '--quiet'])
     except git.GitCommandError as exception:
-        _ctx.logger.error('Failed to update %s/%s', repo.org.login, repo.name)
+        ctx.logger.error('Failed to update %s/%s', repo.org.login, repo.name)
         for msg in parse_git_errors(exception):
-            _ctx.logger.error(msg)
+            ctx.logger.error(msg)
 
 
 def _do_sync(repos_list):
     """Perform repos synchronisation. Intended for internal usage."""
-    assert isinstance(_ctx.base_path, str) and _ctx.base_path
+    assert _proc_ctx is not None, "Context not initialized in this process"
+
+    ctx = _proc_ctx
 
     for repo in repos_list:
-        org_path = os.path.join(_ctx.base_path, repo.org.login)
+        org_path = os.path.join(ctx.base_path, repo.org.login)
         repo_path = os.path.join(org_path, repo.name)
         git_path = os.path.join(repo_path, '.git')
 
         if os.path.exists(repo_path):
             if os.path.isfile(repo_path):
-                _ctx.logger.error(
+                ctx.logger.error(
                     'Unable to sync %s. The path %s is a regular file',
                     repo.name,
                     repo_path)
                 continue
 
             if not os.access(repo_path, os.W_OK | os.X_OK):
-                _ctx.logger.error(
+                ctx.logger.error(
                     'Unable to sync %s. The path %s is not writeable',
                     repo.name,
                     repo_path)
@@ -120,14 +122,14 @@ def _do_sync(repos_list):
             # We're going to run a Git command, but weren't inside a
             # local Git repository.
             if not os.path.exists(git_path):
-                _ctx.logger.debug('Remove wrong formed local repo from %s',
+                ctx.logger.debug('Remove wrong formed local repo from %s',
                                   repo_path)
                 shutil.rmtree(repo_path, ignore_errors=True)
 
         if os.path.exists(git_path):
-            fetch(repo, repo_path)
+            fetch(repo, ctx)
         else:
-            clone(repo, repo_path)
+            clone(repo, ctx)
 
 
 def _init_process(verbose=False, quiet=False, base_path=None):
@@ -140,12 +142,11 @@ def _init_process(verbose=False, quiet=False, base_path=None):
 
     # Setup logger for use within multiprocessing pool
     setup_logger(verbose, quiet)
+    logger = logging.getLogger(__name__)
+    logger.info('Initializing process')
 
-    # Setup git base path for use within multiprocessing pool
-    _ctx.base_path = base_path
-
-    _ctx.logger = logging.getLogger(f'{__name__}')
-    _ctx.logger.info('Initializing process')
+    global _proc_ctx
+    _proc_ctx = Context(base_path=base_path, logger=logger)
 
 
 def sync(org: Organization, repos: list, base_path: str, **kwargs):
@@ -158,27 +159,28 @@ def sync(org: Organization, repos: list, base_path: str, **kwargs):
     :keyword bool quiet: Disable info logging
     :keyword int jobs: the number of worker processes to use
     """
-    _ctx.logger.info('Sync repos for %s', org.login)
+    verbose = kwargs.get('verbose', False)
+    quiet = kwargs.get('quiet', False)
+    jobs = kwargs.get('jobs', multiprocessing.cpu_count())
+
+    setup_logger(verbose, quiet)
+    main_logger = logging.getLogger(__name__)
+    main_logger.info('Sync repos for %s', org.login)
 
     org_path = os.path.join(base_path, org.login)
-
-    # Just in case create directories recursively
     if not os.path.exists(org_path):
-        _ctx.logger.debug('Creating directory %s', org_path)
+        main_logger.debug('Creating directory %s', org_path)
         os.makedirs(org_path)
-
-    jobs = kwargs.get('jobs')
-    if not jobs:
-        jobs = multiprocessing.cpu_count()
 
     def chunks(lst, n):
         """Yield successive n-sized chunks from lst."""
         for i in range(0, len(lst), n):
             yield lst[i:i + n]
 
-    _ctx.logger.info('Processes to be spawned: %s', jobs)
-    with multiprocessing.Pool(processes=jobs, initializer=_init_process,
-                              initargs=(kwargs.get('verbose', False),
-                                        kwargs.get('quiet', False),
-                                        base_path)) as pool:
+    main_logger.info('Processes to be spawned: %s', jobs)
+    with multiprocessing.Pool(
+            processes=jobs,
+            initializer=_init_process,
+            initargs=(verbose, quiet, base_path)
+    ) as pool:
         pool.map(_do_sync, chunks(repos, jobs))

--- a/poetry.lock
+++ b/poetry.lock
@@ -417,6 +417,41 @@ test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "debugpy"
+version = "1.8.9"
+description = "An implementation of the Debug Adapter Protocol for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "debugpy-1.8.9-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:cfe1e6c6ad7178265f74981edf1154ffce97b69005212fbc90ca22ddfe3d017e"},
+    {file = "debugpy-1.8.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ada7fb65102a4d2c9ab62e8908e9e9f12aed9d76ef44880367bc9308ebe49a0f"},
+    {file = "debugpy-1.8.9-cp310-cp310-win32.whl", hash = "sha256:c36856343cbaa448171cba62a721531e10e7ffb0abff838004701454149bc037"},
+    {file = "debugpy-1.8.9-cp310-cp310-win_amd64.whl", hash = "sha256:17c5e0297678442511cf00a745c9709e928ea4ca263d764e90d233208889a19e"},
+    {file = "debugpy-1.8.9-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:b74a49753e21e33e7cf030883a92fa607bddc4ede1aa4145172debc637780040"},
+    {file = "debugpy-1.8.9-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62d22dacdb0e296966d7d74a7141aaab4bec123fa43d1a35ddcb39bf9fd29d70"},
+    {file = "debugpy-1.8.9-cp311-cp311-win32.whl", hash = "sha256:8138efff315cd09b8dcd14226a21afda4ca582284bf4215126d87342bba1cc66"},
+    {file = "debugpy-1.8.9-cp311-cp311-win_amd64.whl", hash = "sha256:ff54ef77ad9f5c425398efb150239f6fe8e20c53ae2f68367eba7ece1e96226d"},
+    {file = "debugpy-1.8.9-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:957363d9a7a6612a37458d9a15e72d03a635047f946e5fceee74b50d52a9c8e2"},
+    {file = "debugpy-1.8.9-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e565fc54b680292b418bb809f1386f17081d1346dca9a871bf69a8ac4071afe"},
+    {file = "debugpy-1.8.9-cp312-cp312-win32.whl", hash = "sha256:3e59842d6c4569c65ceb3751075ff8d7e6a6ada209ceca6308c9bde932bcef11"},
+    {file = "debugpy-1.8.9-cp312-cp312-win_amd64.whl", hash = "sha256:66eeae42f3137eb428ea3a86d4a55f28da9bd5a4a3d369ba95ecc3a92c1bba53"},
+    {file = "debugpy-1.8.9-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:957ecffff80d47cafa9b6545de9e016ae8c9547c98a538ee96ab5947115fb3dd"},
+    {file = "debugpy-1.8.9-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1efbb3ff61487e2c16b3e033bc8595aea578222c08aaf3c4bf0f93fadbd662ee"},
+    {file = "debugpy-1.8.9-cp313-cp313-win32.whl", hash = "sha256:7c4d65d03bee875bcb211c76c1d8f10f600c305dbd734beaed4077e902606fee"},
+    {file = "debugpy-1.8.9-cp313-cp313-win_amd64.whl", hash = "sha256:e46b420dc1bea64e5bbedd678148be512442bc589b0111bd799367cde051e71a"},
+    {file = "debugpy-1.8.9-cp38-cp38-macosx_14_0_x86_64.whl", hash = "sha256:472a3994999fe6c0756945ffa359e9e7e2d690fb55d251639d07208dbc37caea"},
+    {file = "debugpy-1.8.9-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365e556a4772d7d0d151d7eb0e77ec4db03bcd95f26b67b15742b88cacff88e9"},
+    {file = "debugpy-1.8.9-cp38-cp38-win32.whl", hash = "sha256:54a7e6d3014c408eb37b0b06021366ee985f1539e12fe49ca2ee0d392d9ceca5"},
+    {file = "debugpy-1.8.9-cp38-cp38-win_amd64.whl", hash = "sha256:8e99c0b1cc7bf86d83fb95d5ccdc4ad0586d4432d489d1f54e4055bcc795f693"},
+    {file = "debugpy-1.8.9-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:7e8b079323a56f719977fde9d8115590cb5e7a1cba2fcee0986ef8817116e7c1"},
+    {file = "debugpy-1.8.9-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6953b335b804a41f16a192fa2e7851bdcfd92173cbb2f9f777bb934f49baab65"},
+    {file = "debugpy-1.8.9-cp39-cp39-win32.whl", hash = "sha256:7e646e62d4602bb8956db88b1e72fe63172148c1e25c041e03b103a25f36673c"},
+    {file = "debugpy-1.8.9-cp39-cp39-win_amd64.whl", hash = "sha256:3d9755e77a2d680ce3d2c5394a444cf42be4a592caaf246dbfbdd100ffcf7ae5"},
+    {file = "debugpy-1.8.9-py2.py3-none-any.whl", hash = "sha256:cc37a6c9987ad743d9c3a14fa1b1a14b7e4e6041f9dd0c8abf8895fe7a97b899"},
+    {file = "debugpy-1.8.9.zip", hash = "sha256:1339e14c7d980407248f09824d1b25ff5c5616651689f1e0f0e51bdead3ea13e"},
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.15"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
@@ -1663,4 +1698,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <4"
-content-hash = "055649688ec7e5e7d121e5022bb8ed581a9e561d05e8327cde4baec75a724eed"
+content-hash = "87ad60e8c0523ebad494f8f4d6aa919105f6aeedba071d9c929c00533b680c17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ furo = ">=2023.3.27"
 [tool.poetry.group.build.dependencies]
 twine = "^5.1.1"
 
+
+[tool.poetry.group.dev.dependencies]
+debugpy = "^1.8.9"
+
 [tool.pytest.ini_options]
 addopts = "--verbose --doctest-modules --durations=25"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,12 @@
 
 from unittest.mock import MagicMock
 
-import pytest
 from github import Github
 from github.GithubException import UnknownObjectException
+import pytest
 
 from gstore.client import Client
-from gstore.repo import _Context, Organization, Repository
+from gstore.repo import Context, Organization, Repository
 
 
 class MicroMock:
@@ -158,11 +158,6 @@ def repository(organization):
 
 
 @pytest.fixture
-def repo_target(tmpdir):
-    target = tmpdir.join('Acme', 'test_repo')
-    return str(target)
-
-
-@pytest.fixture
-def test_context(repo_target):
-    return _Context(base_path=repo_target, logger=MagicMock())
+def test_context(tmpdir):
+    context = Context(base_path=tmpdir, logger=MagicMock())
+    return context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,9 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from github import Github
 from github.GithubException import UnknownObjectException
-import pytest
 
 from gstore.client import Client
 from gstore.repo import Context, Organization, Repository

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -138,7 +138,7 @@ def test_sync(mocker, caplog, organization, repository, test_context):
         ("gstore.repo", logging.INFO, "Sync repos for " + organization.login),
         ("gstore.repo", logging.DEBUG,
          "Creating directory " + os.path.join(base_path, organization.login)),
-        ("gstore.repo", logging.INFO, "Processes to be spawned: 4"),
+        ("gstore.repo", logging.INFO, "Processes to be spawned: 1"),
     ]
 
     mock_pool.map.assert_called_once()

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -15,7 +15,7 @@
 
 import logging
 import os
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 from git import GitCommandError
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
+import logging
 import os
-from unittest.mock import call, MagicMock
+from unittest.mock import MagicMock, call
 
 from git import GitCommandError
 
@@ -22,21 +23,26 @@ from gstore.repo import _do_sync
 from gstore.repo import clone, fetch, sync
 
 
-def test_clone_success(mocker, repository, repo_target, test_context):
-    mocker.patch('gstore.repo._ctx', test_context)
+def test_clone_success(mocker, repository, test_context):
+    mocker.patch('gstore.repo._proc_ctx', test_context)
     mock_exists = mocker.patch('os.path.exists')
     mock_removedirs = mocker.patch('os.removedirs')
     mock_clone_from = mocker.patch('git.Repo.clone_from')
+    repo_path = os.path.join(
+        test_context.base_path,
+        repository.org.login,
+        repository.name
+    )
 
     mock_exists.return_value = False
 
-    clone(repository, repo_target)
+    clone(repository, test_context)
 
-    mock_exists.assert_called_once_with(repo_target)
+    mock_exists.assert_called_once_with(repo_path)
     mock_removedirs.assert_not_called()
     mock_clone_from.assert_called_once_with(
         f'git@github.com:{repository.org.login}/{repository.name}.git',
-        repo_target,
+        repo_path,
     )
     test_context.logger.info.assert_called_once_with(
         'Clone repository to %s/%s',
@@ -45,35 +51,40 @@ def test_clone_success(mocker, repository, repo_target, test_context):
     )
 
 
-def test_clone_failure(mocker, repository, repo_target, test_context):
-    mocker.patch('gstore.repo._ctx', test_context)
+def test_clone_failure(mocker, repository, test_context):
+    mocker.patch('gstore.repo._proc_ctx', test_context)
     mock_exists = mocker.patch('os.path.exists')
-    mock_removedirs = mocker.patch('os.removedirs')
+    mock_rmtree = mocker.patch('shutil.rmtree')
     mock_clone_from = mocker.patch('git.Repo.clone_from')
+    repo_path = os.path.join(
+        test_context.base_path,
+        repository.org.login,
+        repository.name
+    )
 
     mock_exists.return_value = True
     mock_clone_from.side_effect = GitCommandError(
         ['git', 'clone'], 1, 'error message')
 
-    clone(repository, repo_target)
+    clone(repository, test_context)
 
-    mock_exists.assert_called_once_with(repo_target)
-    mock_removedirs.assert_called_once_with(repo_target)
+    mock_exists.assert_called_once_with(repo_path)
+    mock_rmtree.assert_called_once_with(repo_path, ignore_errors=True)
     mock_clone_from.assert_called_once_with(
         f'git@github.com:{repository.org.login}/{repository.name}.git',
-        repo_target,
+        repo_path,
     )
     test_context.logger.error.assert_called()
 
 
-def test_fetch_success(mocker, repository, repo_target, test_context):
-    mocker.patch('gstore.repo._ctx', test_context)
+def test_fetch_success(mocker, repository, test_context):
+    mocker.patch('gstore.repo._proc_ctx', test_context)
     mock_repo = mocker.patch('git.Repo')
     mock_local_repo = MagicMock()
     mock_repo.return_value = mock_local_repo
     mock_local_repo.heads = ['master']
 
-    fetch(repository, repo_target)
+    fetch(repository, test_context)
 
     test_context.logger.info.assert_called_once_with(
         'Update %s/%s repository',
@@ -84,8 +95,8 @@ def test_fetch_success(mocker, repository, repo_target, test_context):
     mock_local_repo.git.pull.assert_called_once_with(['--all', '--quiet'])
 
 
-def test_fetch_failure(mocker, repository, repo_target, test_context):
-    mocker.patch('gstore.repo._ctx', test_context)
+def test_fetch_failure(mocker, repository, test_context):
+    mocker.patch('gstore.repo._proc_ctx', test_context)
     mock_repo = mocker.patch('git.Repo')
     mock_local_repo = MagicMock()
     mock_repo.return_value = mock_local_repo
@@ -93,40 +104,41 @@ def test_fetch_failure(mocker, repository, repo_target, test_context):
 
     mock_local_repo.git.fetch.side_effect = GitCommandError(
         ['git', 'fetch'], 1, 'fetch error message')
-    fetch(repository, repo_target)
+    fetch(repository, test_context)
 
     test_context.logger.error.assert_called()
 
 
-def test_do_sync(mocker, repository, repo_target, test_context):
-    mocker.patch('gstore.repo._ctx', test_context)
+def test_do_sync(mocker, repository, test_context):
+    mocker.patch('gstore.repo._proc_ctx', test_context)
     mock_clone = mocker.patch('gstore.repo.clone')
     mock_fetch = mocker.patch('gstore.repo.fetch')
     repos_list = [repository]
 
     _do_sync(repos_list)
 
-    org_path = os.path.join(test_context.base_path, repository.org.login)
-    repo_path = os.path.join(org_path, repository.name)
-    mock_clone.assert_called_once_with(repository, repo_path)
+    mock_clone.assert_called_once_with(repository, test_context)
     mock_fetch.assert_not_called()
 
 
-def test_sync(mocker, organization, repository, repo_target, test_context):
-    mocker.patch('gstore.repo._ctx', test_context)
-    mocker.patch('multiprocessing.cpu_count', return_value=4)
+def test_sync(mocker, caplog, organization, repository, test_context):
+    mocker.patch("gstore.repo._proc_ctx", test_context)
+    mocker.patch("multiprocessing.cpu_count", return_value=4)
     mock_pool = MagicMock()
     mock_pool.__enter__.return_value = mock_pool
-    mocker.patch('multiprocessing.Pool', return_value=mock_pool)
-    mocker.patch('os.makedirs')
+    mocker.patch("multiprocessing.Pool", return_value=mock_pool)
+    mocker.patch("os.makedirs")
 
     repos = [repository]
-    base_path = os.path.dirname(repo_target)
+    base_path = str(test_context.base_path)
 
     sync(organization, repos, base_path)
 
-    test_context.logger.info.assert_has_calls(
-        [call('Sync repos for %s', organization.login)])
-    test_context.logger.debug.assert_called_once_with(
-        'Creating directory %s', os.path.join(base_path, organization.login))
+    assert caplog.record_tuples == [
+        ("gstore.repo", logging.INFO, "Sync repos for " + organization.login),
+        ("gstore.repo", logging.DEBUG,
+         "Creating directory " + os.path.join(base_path, organization.login)),
+        ("gstore.repo", logging.INFO, "Processes to be spawned: 4"),
+    ]
+
     mock_pool.map.assert_called_once()


### PR DESCRIPTION
This change replaces the global `_ctx` variable with a per-process context setup in the multiprocessing pool initializer. Functions now accept a context object directly, enhancing clarity, testability, and maintainability.